### PR TITLE
Missing init file and ignore downloaded files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 *.egg-info/
 results/
 data/*/data
+dist
+build
+*.zip


### PR DESCRIPTION
I had to an a init folder protonets to run the train script.  Also noticed a few downloaded files would have been added to github if they weren't added to the ignore file.